### PR TITLE
Fixed invalid Spark without hadoop URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG SPARK_VERSION=3.1.3
 ARG SPARK_LOG_DIRECTORY=/spark-events
 ENV SPARK_LOG_DIRECTORY=${SPARK_LOG_DIRECTORY}
 WORKDIR /spark
-RUN curl -L https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz | tar xz --strip-components=1 && \
+RUN curl -L https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz | tar xz --strip-components=1 && \
     echo "export SPARK_DIST_CLASSPATH=$(/hadoop/bin/hadoop classpath)" >> conf/spark-env.sh && \
     echo "spark.hadoop.fs.s3a.aws.credentials.provider org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider" > conf/spark-defaults.conf
 


### PR DESCRIPTION
Running `docker build --target spark-shell -t spark-shell .` results in an error because the specified URL does not exist anymore. [Spark 3.1.3](https://spark.apache.org/releases/spark-release-3-1-3.html) seems to have been archived.

Changing the URL to the archived URL in the Dockerfile seems to fix this on my local machine (running Docker).